### PR TITLE
Support for loading in FP8 mode (ROCm/AMD 7000-series)

### DIFF
--- a/modeling/bagel/siglip_navit.py
+++ b/modeling/bagel/siglip_navit.py
@@ -189,7 +189,10 @@ class SiglipVisionEmbeddings(nn.Module):
 
         patch_embeds = self.patch_embedding(packed_pixel_values)
         if not self.config.rope:
-            embeddings = patch_embeds + self.position_embedding(packed_flattened_position_ids)
+            pos_embeds = self.position_embedding(packed_flattened_position_ids)
+            if pos_embeds.dtype == torch.float8_e4m3fn:
+                pos_embeds = pos_embeds.to(patch_embeds.dtype)
+            embeddings = patch_embeds + pos_embeds
         else:
             embeddings = patch_embeds
         return embeddings


### PR DESCRIPTION
Unfortunately, the 7900XTX and other consumer-grade AMD GPUs don't really support bitsandbytes. Or dfloat11. But, FP8 support works fine. With this patch, I can load and run BAGEL on a 7900XTX. Unfortunately, it still takes about 17GB at max, so it's too much for a 16GB card, but it does work, and it's a heck of a lot faster than CPU. Basically this patch fixes AMD/ROCm support for 7000-series GPUs on ROCm.

Something seems to be "up" with `infer_auto_device_map`. I don't know if it's a ROCm-specific problem. It looks like it's deciding based on the assumption that the tensors will be 32-bit (???), and so without multiplying my detected memory size by 4, it still offloaded most of it, leaving my GPU largely empty. The model easily fits within 24GB in FP8, and the multiplication appears to convince `infer_auto_device_map` to do the right math, if in a somewhat brutish way. The rest of the patch should be relatively obvious.

Loads the FP16 model with on-the-fly quantization. Because most math isn't supported in FP8, the weights are changed dynamically as needed, so a few checks are added to perform the upconversion. I don't believe these checks should affect anything else, but I can't test any other mode since I don't have an NVidia card to test on, so I'd appreciate if somebody would make sure I'm not breaking everything :)

I have a similar PR for the original BAGEL repo as well.

![bagel-fp8](https://github.com/user-attachments/assets/492d7384-dc8e-4a87-b2a1-884bace48337)
![ComfyUI_00131](https://github.com/user-attachments/assets/d10ffa8b-3f0e-4108-9e67-eb2dd56a5dbc)
